### PR TITLE
Using MR in common module.

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -10,6 +10,8 @@ kotlin {
 
     jvm("desktop")
 
+    ios()
+
 //    listOf(
 //        iosX64(),
 //        iosArm64(),
@@ -54,6 +56,9 @@ kotlin {
             dependencies {
                 implementation(compose.desktop.common)
             }
+        }
+        val iosMain by getting {
+            dependsOn(commonMain)
         }
     }
 }

--- a/shared/src/androidMain/kotlin/main.android.kt
+++ b/shared/src/androidMain/kotlin/main.android.kt
@@ -1,13 +1,5 @@
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.res.painterResource
-import com.icerockdev.app.MR
-import com.myapplication.common.R
-import dev.icerock.moko.resources.compose.painterResource
 
 actual fun getPlatformName(): String = "Android"
-
-@Composable
-actual fun getCatImage(): Painter = painterResource(R.drawable.background_cat)
 
 @Composable fun MainView() = App()

--- a/shared/src/commonMain/kotlin/App.kt
+++ b/shared/src/commonMain/kotlin/App.kt
@@ -17,12 +17,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.bpavuk.catfacts.CatFacts
+import com.icerockdev.app.MR
+import dev.icerock.moko.resources.compose.painterResource
 import kotlinx.coroutines.launch
 
 val sdk = CatFacts()
@@ -33,7 +34,7 @@ fun App() {
     MaterialTheme {
         Box {
             Image(
-                painter = getCatImage(),
+                painter = painterResource(MR.images.background_cat),
                 contentDescription = null,
                 modifier = Modifier
                     .blur(32.dp),
@@ -129,5 +130,3 @@ fun MetroButton(
 
 expect fun getPlatformName(): String
 
-@Composable
-expect fun getCatImage(): Painter

--- a/shared/src/desktopMain/kotlin/main.desktop.kt
+++ b/shared/src/desktopMain/kotlin/main.desktop.kt
@@ -1,12 +1,7 @@
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.res.painterResource
 
 actual fun getPlatformName(): String = "Desktop"
-
-@Composable
-actual fun getCatImage(): Painter = painterResource("images/background_cat.jpg")
 
 @Composable fun MainView() = App()
 


### PR DESCRIPTION
Added Ios target for correct display of MR class in common module, if only JVM targets are used, the IDE does not display the MR class in the code complete.